### PR TITLE
Fix build errors in Dose Ninja

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,7 +26,12 @@ import { routes } from './app.routes';
     DosageCorrectionComponent,
   ],
   declarations: [
-    AppComponent
+    AppComponent,
+    LoginComponent,
+    RegisterComponent,
+    MedicationSearchComponent,
+    MedicationTrackingComponent,
+    DosageCorrectionComponent
   ],
   providers: [],
 })


### PR DESCRIPTION
Add missing component declarations to `@NgModule` in `src/app/app.module.ts`.

* Declare `LoginComponent`, `RegisterComponent`, `MedicationSearchComponent`, `MedicationTrackingComponent`, and `DosageCorrectionComponent` in the `@NgModule` declarations array to resolve unknown element errors.

